### PR TITLE
Update antora-playbook.yml

### DIFF
--- a/playbook-repo/antora-playbook.yml
+++ b/playbook-repo/antora-playbook.yml
@@ -18,4 +18,10 @@ ui:
   bundle:
     url: https://github.com/Vandit1604/jenkins-ui-project/raw/main/build/ui-bundle.zip
     snapshot: true
+  supplemental_files:
+  - path: ui.yml
+    contents: |
+      static_files:
+      - .nojekyll
+  - path: .nojekyll
 # --ui-bundle-url=/home/vandit/gsoc-project-demo/jenkins-ui-project/build/ui-bundle.zip


### PR DESCRIPTION
Use the supplemental UI to disable the default Jekyll and underscore files “feature” of GitHub Pages.

WARNING: Try PR #4 first, if that doesn't work then try this. 